### PR TITLE
Makefile added with setup, serve and clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+SHELL := /bin/bash
+
+setup:
+	python3 -m venv venv
+	pip install -r requirements.txt
+
+serve:
+	sudo service postgresql start
+	uvicorn backend.main:app --reload
+
+clean:
+	sudo find . -type f -name "*.pyc" -delete
+	sudo find . -type d -name "__pycache__" -delete
+	sudo rm -rf venv


### PR DESCRIPTION
Added Makefile to streamline setup, server start, and clean-up processes:

The setup target creates a Python virtual environment and installs dependencies.

The serve target starts the PostgreSQL service and runs the FastAPI app.

The clean target removes Python cache files and the virtual environment.